### PR TITLE
1.21.4 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
-    implementation("net.minestom:minestom-snapshots:7589b3b655")
+    implementation("net.minestom:minestom-snapshots:0366b58bfe")
     implementation("org.tinylog:slf4j-tinylog:2.7.0")
     implementation("org.tinylog:tinylog-impl:2.7.0")
 }

--- a/src/main/kotlin/minestom/OnJoin.kt
+++ b/src/main/kotlin/minestom/OnJoin.kt
@@ -3,37 +3,39 @@ package minestom
 import me.chriss99.minestom.BlockSymbol
 import me.chriss99.minestom.createBasePlate
 import me.chriss99.minestom.createCursor
-import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.entity.GameMode
 import net.minestom.server.entity.PlayerSkin
 import net.minestom.server.event.GlobalEventHandler
 import net.minestom.server.event.player.AsyncPlayerConfigurationEvent
+import net.minestom.server.event.player.PlayerLoadedEvent
 import net.minestom.server.event.player.PlayerSkinInitEvent
 import net.minestom.server.instance.InstanceContainer
 import net.minestom.server.item.ItemStack
-import net.minestom.server.timer.TaskSchedule
 
 fun onJoin(eventHandler: GlobalEventHandler, instanceContainer: InstanceContainer) {
-    eventHandler.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
-        val player = event.player
-        event.spawningInstance = instanceContainer
-        player.respawnPoint = Pos(0.0, 41.0, 0.0)
-        player.gameMode = GameMode.ADVENTURE
 
-        MinecraftServer.getSchedulerManager().scheduleTask({
-            BlockSymbol.entries.forEach { blockSymbol ->
-                val material = blockSymbol.block.registry().material() ?: return@forEach
-                val item = ItemStack.of(material)
-                player.inventory.addItemStack(item)
-            }
-            player.isFlying = true
-            createBasePlate(player, instanceContainer)
-            createCursor(player, instanceContainer)
-        }, TaskSchedule.tick(5), TaskSchedule.stop())
+    eventHandler.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
+        event.spawningInstance = instanceContainer
+        event.player.respawnPoint = Pos(0.0, 41.0, 0.0)
+    }
+
+    eventHandler.addListener(PlayerLoadedEvent::class.java) { event ->
+        val player = event.player
+
+        player.gameMode = GameMode.ADVENTURE
+        BlockSymbol.entries.forEach { blockSymbol ->
+            val material = blockSymbol.block.registry().material() ?: return@forEach
+            val item = ItemStack.of(material)
+            player.inventory.addItemStack(item)
+        }
+        player.isFlying = true
+        createBasePlate(player, instanceContainer)
+        createCursor(player, instanceContainer)
     }
 
     eventHandler.addListener(PlayerSkinInitEvent::class.java) { event ->
         event.skin = PlayerSkin.fromUsername(event.player.username)
     }
+
 }

--- a/src/main/kotlin/minestom/World.kt
+++ b/src/main/kotlin/minestom/World.kt
@@ -1,16 +1,15 @@
 package minestom
 
+import net.kyori.adventure.text.format.NamedTextColor
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.BlockVec
 import net.minestom.server.instance.InstanceContainer
 import net.minestom.server.instance.Weather
 import net.minestom.server.instance.block.Block
-import net.minestom.server.particle.Particle
 import net.minestom.server.registry.DynamicRegistry
 import net.minestom.server.world.DimensionType
 import net.minestom.server.world.biome.Biome
 import net.minestom.server.world.biome.BiomeEffects
-import net.minestom.server.world.biome.BiomeParticle
 
 val BASE_BLOCK: Block = Block.GRAY_CONCRETE
 
@@ -42,11 +41,13 @@ fun initInstance(): InstanceContainer {
 fun createVoidBiome() {
     val biome = Biome.builder().effects(
         BiomeEffects.builder()
-            .skyColor(0x000000)
-            .fogColor(0x000000)
+            .skyColor(NamedTextColor.BLACK)
+            .fogColor(NamedTextColor.BLACK)
+            .waterColor(NamedTextColor.BLACK)
+            .waterFogColor(NamedTextColor.BLACK)
             .build()
         )
-        .precipitation(Biome.Precipitation.NONE)
+        .hasPrecipitation(false)
         .build()
     val biomeRegistry = MinecraftServer.getBiomeRegistry()
     biomeRegistry.register("void", biome)


### PR DESCRIPTION
This PR aims to update the master branch to Minestom 1.21.4, which was merged into master about a 3 days ago.

### Changes caused by update
- Biomes when created now require `sky`, `fog`, `water` and `waterFog` colors
- Biome colors now use RGBLike
- `precipitation` has been removed and now uses `hasPrecipitation(Boolean)` to match minecraft's data driven registry
- `onJoin` kotlie file now uses `PlayerLoadedEvent` for handling the scheduler code in the `AsyncPlayerConfigurationEvent`
